### PR TITLE
remove bundler from gemspec bc it is redundant

### DIFF
--- a/wax_theme.gemspec
+++ b/wax_theme.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'jekyll', '~> 3.8'
   spec.add_runtime_dependency 'wax_tasks', '>= 1.0.1', '< 1.1'
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'html-proofer', '~> 3.10'
 end


### PR DESCRIPTION
fixes https://github.com/minicomp/wiki/issues/12
bundler is needed to run `bundle install` in the first place; therefore, having it in the `gemspec` is unnecessary & unnecessarily particular wrt the `bundler` version